### PR TITLE
fe-feat/taskInputComponent

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
+        "react-icons": "^4.11.0",
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
         "styled-components": "^6.0.8",
@@ -15193,6 +15194,14 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
+    "react-icons": "^4.11.0",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.0.8",

--- a/frontend/src/components/taskInputComponents.tsx
+++ b/frontend/src/components/taskInputComponents.tsx
@@ -1,5 +1,78 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { HiMicrophone, HiChevronDoubleUp } from 'react-icons/hi';
+import styled from 'styled-components';
 
-export default function taskInputComponents() {
-    return <div>taskInputComponents</div>;
+const TaskInputComponent = styled.div`
+    display: felx;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: flex-start;
+    
+    width: 80%;
+    height: 100%;
+    
+    fill: #FFFF;
+    filter: drop-shadow(4px 4px 10px rgba(54, 54, 54, 0.25)) drop-shadow(-4px -4px 4px rgba(255, 255, 255, 0.25));
+    
+    border-radius: 20px;
+    border: 1;
+    
+    background-color: #ffffff;
+
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
+`;
+const TaskInput = styled.textarea`
+    flex: 1;
+    width: 90%;
+    border: 0;
+    color: #828282;
+    font-size: 15px;
+    outline: 0;
+    resize: none;
+`;
+const ActionButtons = styled.button`
+    flex: 2;
+
+    border: 0;
+    height:100%;
+    padding-top: 0px;
+    padding-left: 0px;
+    padding-bottom: 0px;
+    padding-right: 0px;
+    flex: 1;
+    color: #f0f0f0;
+    background-color: #ffff;
+    font-size: 25px;
+`;
+
+export default function TaskInputComponents() {
+    
+    const [inputText, setText] = useState("");
+    const eventInput =(e:React.ChangeEvent<HTMLTextAreaElement>)=>{
+        setText(e.target.value);
+    }
+    
+    const onSubmit = () => {
+        console.log("submit");
+    }
+    const onVoice = () =>{
+        console.log("voice");
+    }
+
+    return(
+        <>
+            <TaskInputComponent>
+                <TaskInput onChange={(e)=>eventInput(e)} value={inputText} />
+                <ActionButtons onClick={onVoice}>
+                    <HiMicrophone />
+                </ActionButtons>
+                <ActionButtons>
+                    <HiChevronDoubleUp onClick={onSubmit}/>
+                </ActionButtons>
+            </TaskInputComponent>
+        </>
+    );
 }

--- a/frontend/src/components/taskInputComponents.tsx
+++ b/frontend/src/components/taskInputComponents.tsx
@@ -3,7 +3,7 @@ import { HiMicrophone, HiChevronDoubleUp } from 'react-icons/hi';
 import styled from 'styled-components';
 
 const TaskInputComponent = styled.div`
-    display: felx;
+    display: flex;
     flex-direction: row;
     justify-content: flex-start;
     align-items: flex-start;


### PR DESCRIPTION
<!-- Pull Request 제목 양식 : [파트명(be, fe, ai)]-[기능타입(아래 타입 중 하나)]/[기능명(영어로]) -->
<!-- ex) be-feat/serverSetUp -->
<!-- 기능 타입은 feat, hotfix, bugfix, test, refac, etc -->

## :racehorse: 작업 분류
- [x] 기능 개발 
- [ ] 리팩토링/스타일 수정
- [ ] 테스트
- [ ] 버그수정
- [ ] 기타(작성: )

<br/>

## :package: 변경사항을 설명해주세요
- task input component의 UI 개발

<br/>

## 🐞 직면했던 문제
- SDP 패킷을 보내는 것에 있어, signal server가 있어야 의미 있는 구현을 할 수 잇었음
- 따라서 이번 taskInputCompoenent는 Task를 Server로 보내는 기능 받은 음성을 음성처리 Server로 보내는 기능은 빠진 상태임

<br/>

<!-- 아래 부분들은 사용하지 않는다면 지워주세요 -->
## ⚔️ 중점적으로 볼 부분(선택사항)
- react-icons를 라이브러리로 추가하였는데, 라이브러리 충돌이 dev에서 있는지 보야아함
<br/>
